### PR TITLE
Does not apply prefix when it is empty

### DIFF
--- a/src/Subscriber/PrefixSubscriber.php
+++ b/src/Subscriber/PrefixSubscriber.php
@@ -62,7 +62,7 @@ class PrefixSubscriber implements EventSubscriber
 
     private function addPrefix($name)
     {
-        if (mb_strpos($name, $this->prefix) === 0) {
+        if (empty($this->prefix) || mb_strpos($name, $this->prefix) === 0) {
             return $name;
         }
 


### PR DESCRIPTION
Fix warning: "mb_strpos(): Empty delimiter"