### PR TITLE
Update composer.json dependencies for Doctrine 3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,11 +2,12 @@
     "name": "roukmoute/doctrine-prefix-bundle",
     "description": "Listener that prefixes tables and sequences",
     "require": {
-        "doctrine/event-manager": "^1.1",
-        "symfony/config": "3.4.*|4.4.*",
-        "symfony/http-kernel": "3.4.*|4.4.*",
-        "symfony/dependency-injection": "3.4.*|4.4.*",
-        "doctrine/orm": "^2.7"
+        "php": "^8.1",
+        "doctrine/event-manager": "^2.0",
+        "doctrine/orm": "^3.0",
+        "symfony/config": "^6.4 || ^7.0",
+        "symfony/dependency-injection": "^6.4 || ^7.0",
+        "symfony/http-kernel": "^6.4 || ^7.0"
     },
     "license": "MIT",
     "authors": [
@@ -21,7 +22,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "2.0-dev"
         }
     }
 }


### PR DESCRIPTION
## Summary
- Update PHP requirement to ^8.1
- Update doctrine/event-manager to ^2.0
- Update doctrine/orm to ^3.0
- Update Symfony packages to ^6.4 || ^7.0
- Update branch-alias to 2.0-dev

## Test plan
- [ ] Run `composer validate`
- [ ] Verify bundle can be installed in a Symfony 7 project

Closes #10