### PR TITLE
Replace ClassMetadataInfo with ClassMetadata

### DIFF
--- a/src/EventListener/TablePrefixListener.php
+++ b/src/EventListener/TablePrefixListener.php
@@ -79,7 +79,7 @@ class TablePrefixListener
         }
 
         foreach ($classMetadata->getAssociationMappings() as $fieldName => $mapping) {
-            if ($mapping['type'] == \Doctrine\ORM\Mapping\ClassMetadataInfo::MANY_TO_MANY
+            if ($mapping['type'] == ClassMetadata::MANY_TO_MANY
                 && isset($classMetadata->associationMappings[$fieldName]['joinTable']['name'])
             ) {
                 $mappedTableName
@@ -94,7 +94,7 @@ class TablePrefixListener
     {
         $em = $args->getEntityManager();
         $platform = $em->getConnection()->getDatabasePlatform();
-        if ($platform instanceof \Doctrine\DBAL\Platforms\PostgreSqlPlatform) {
+        if ($platform instanceof \Doctrine\DBAL\Platforms\PostgreSQLPlatform) {
             if ($classMetadata->isIdGeneratorSequence()) {
                 $newDefinition = $classMetadata->sequenceGeneratorDefinition;
                 $newDefinition['sequenceName'] = $this->addPrefix($newDefinition['sequenceName']);


### PR DESCRIPTION
## Summary
- Replace `ClassMetadataInfo::MANY_TO_MANY` with `ClassMetadata::MANY_TO_MANY`
- Update `PostgreSqlPlatform` to `PostgreSQLPlatform` (DBAL 4 naming convention)

## Context
`ClassMetadataInfo` has been removed in Doctrine ORM 3.0. The `MANY_TO_MANY` constant now lives directly in `ClassMetadata`.

## Test plan
- [ ] Verify many-to-many join table prefixing works correctly

Closes #12