### PR TITLE
Add support for prefixing unique constraints

### DIFF
--- a/src/EventListener/TablePrefixListener.php
+++ b/src/EventListener/TablePrefixListener.php
@@ -42,6 +42,7 @@ class TablePrefixListener
 
         $this->prefixTable($classMetadata);
         $this->prefixIndexes($classMetadata);
+        $this->prefixUniqueConstraints($classMetadata);
         $this->prefixManyToManyJoinTables($classMetadata);
         $this->prefixSequence($args, $classMetadata);
     }
@@ -97,6 +98,22 @@ class TablePrefixListener
             $prefixedIndexes[$this->addPrefix((string) $indexName)] = $indexConfig;
         }
         $classMetadata->table['indexes'] = $prefixedIndexes;
+    }
+
+    /**
+     * @param ClassMetadata<object> $classMetadata
+     */
+    private function prefixUniqueConstraints(ClassMetadata $classMetadata): void
+    {
+        if (!isset($classMetadata->table['uniqueConstraints'])) {
+            return;
+        }
+
+        $prefixedConstraints = [];
+        foreach ($classMetadata->table['uniqueConstraints'] as $constraintName => $constraintConfig) {
+            $prefixedConstraints[$this->addPrefix((string) $constraintName)] = $constraintConfig;
+        }
+        $classMetadata->table['uniqueConstraints'] = $prefixedConstraints;
     }
 
     /**

--- a/tests/EventListener/TablePrefixListenerTest.php
+++ b/tests/EventListener/TablePrefixListenerTest.php
@@ -81,6 +81,25 @@ class TablePrefixListenerTest extends TestCase
         self::assertArrayNotHasKey('idx_username', $classMetadata->table['indexes']);
     }
 
+    public function testUniqueConstraintNamesArePrefixed(): void
+    {
+        $listener = new TablePrefixListener('app_', [], 'UTF-8');
+
+        $classMetadata = $this->createClassMetadata('user');
+        $classMetadata->table['uniqueConstraints'] = [
+            'uniq_email' => ['columns' => ['email']],
+            'uniq_username' => ['columns' => ['username']],
+        ];
+        $eventArgs = $this->createEventArgs($classMetadata);
+
+        $listener->loadClassMetadata($eventArgs);
+
+        self::assertArrayHasKey('app_uniq_email', $classMetadata->table['uniqueConstraints']);
+        self::assertArrayHasKey('app_uniq_username', $classMetadata->table['uniqueConstraints']);
+        self::assertArrayNotHasKey('uniq_email', $classMetadata->table['uniqueConstraints']);
+        self::assertArrayNotHasKey('uniq_username', $classMetadata->table['uniqueConstraints']);
+    }
+
     public function testManyToManyJoinTableIsPrefixed(): void
     {
         $listener = new TablePrefixListener('app_', [], 'UTF-8');


### PR DESCRIPTION
## Summary
Add prefix support for unique constraints defined in entity mapping.

Previously, only regular indexes were prefixed. Unique constraints defined with `uniqueConstraints` were not prefixed, leading to inconsistent naming.

## Example

```php
#[ORM\Entity]
#[ORM\Table(uniqueConstraints: [
    new ORM\UniqueConstraint(name: 'uniq_email', columns: ['email'])
])]
class User { }
```

With prefix `app_`, the unique constraint will now be named `app_uniq_email` instead of `uniq_email`.

## Test plan
- [x] Added unit test for unique constraint prefixing

Closes #2